### PR TITLE
make crate independent of std

### DIFF
--- a/src/generic_fletcher.rs
+++ b/src/generic_fletcher.rs
@@ -5,14 +5,13 @@
 //! some basic requirments on the type used for the checksum, all of
 //! which are met by integral types.
 
-use std::ops::Add;
-use std::marker::PhantomData;
-use std::marker::Copy;
+use core::marker::Copy;
+use core::marker::PhantomData;
+use core::ops::Add;
 
 /// Defines the required traits for the accumulator type
 /// used in the algorithm
-pub trait FletcherAccumulator<T>
-    : Add<Self> + From<T> + From<<Self as Add>::Output> + Copy {
+pub trait FletcherAccumulator<T>: Add<Self> + From<T> + From<<Self as Add>::Output> + Copy {
     /// Should return a reasonable default value
     ///
     /// Usual default values have the least significant bits set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,13 @@
-pub mod generic_fletcher;
+#![no_std]
+
 pub mod fletcher16;
 pub mod fletcher32;
 pub mod fletcher64;
+pub mod generic_fletcher;
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
I'm using this crate in an embedded project, which doesn't use std.

This crate doesn't actually need it, so here's a PR to make it work in no_std environments.

I basically just changed the uses from `std::*` to `core::*`, and fixed the tests.