### PR TITLE
Fix overflow behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@ extern crate std;
 extern crate byteorder;
 
 use core::{
+    cmp::PartialEq,
     convert::From,
     ops::{Add, AddAssign, BitAnd, BitOr, Shl, Shr},
-    cmp::PartialEq
 };
 
 /// Base set of values and


### PR DESCRIPTION
Reported as a part of #8 , we are mishandling overflow values in the output. `0xFF` (etc) should not show up in the output, instead it should be replaced with `0x00`. Our implementation of the algorithm still handles overflows correctly internally, it's just the output values that are a problem.

This fix adds a quick check to the `reduce()` function to replace any `0xFF` after the reduction with `0x00`.