### PR TITLE
Derive Clone, Copy, Debug on struct Fletcher<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ impl FletcherAccumulator for u64 {
 /// chunks of data. If you have an entire block of data the functions
 /// [`calc_fletcher16`], [`calc_fletcher32`], [`calc_fletcher64`] simplify
 /// the process.
+#[derive(Clone, Copy, Debug)]
 pub struct Fletcher<T>
 where
     T: FletcherAccumulator,


### PR DESCRIPTION
Hi,

It is not possible to use #[derive(Copy)] on structs that contain Fletcher<T> as a property; this can be inconvenient in some use cases.

Since trait FletcherAccumulator is implemented on types that implement Copy, and Copy can be implemented only when Clone is, i do not see why adding #[derive(Clone, Copy)] would not be welcome.

In my projects i often use #[derive(Debug)] for easier debugging, but once some struct has property of type Fletcher<T>, it is not possible to use #[derive(Debug)] anymore since Fletcher does not implement Debug. While the default derived Debug formatter might not be the prettiest, it at least allows to derive Debug on parent structs which often is satisfactory enough.

Sorry that i send this pull request of of the blue, but it is so trivial that i thought opening an issue is not worth the trouble.

